### PR TITLE
Update request future (#1)

### DIFF
--- a/loggly/handlers.py
+++ b/loggly/handlers.py
@@ -1,7 +1,5 @@
 import logging
 import logging.handlers
-
-import socket
 import traceback
 
 from requests_futures.sessions import FuturesSession
@@ -9,12 +7,13 @@ from requests_futures.sessions import FuturesSession
 session = FuturesSession()
 
 
-
-def response_hook(resp, *args, **kwargs):
+def response_callback(resp, *args, **kwargs):
     """ Don't do anything with the response """
     pass
 
-session.hooks['response'] = response_hook
+
+session.hooks['response'] = response_callback
+
 
 class HTTPSHandler(logging.Handler):
     def __init__(self, url, fqdn=False, localname=None, facility=None):

--- a/loggly/handlers.py
+++ b/loggly/handlers.py
@@ -10,11 +10,11 @@ session = FuturesSession()
 
 
 
-def bg_cb(resp, *args, **kwargs):
+def response_hook(resp, *args, **kwargs):
     """ Don't do anything with the response """
     pass
 
-session.hooks['response'] = bg_cb
+session.hooks['response'] = response_hook
 
 class HTTPSHandler(logging.Handler):
     def __init__(self, url, fqdn=False, localname=None, facility=None):

--- a/loggly/handlers.py
+++ b/loggly/handlers.py
@@ -9,10 +9,12 @@ from requests_futures.sessions import FuturesSession
 session = FuturesSession()
 
 
-def bg_cb(sess, resp):
+
+def bg_cb(resp, *args, **kwargs):
     """ Don't do anything with the response """
     pass
 
+session.hooks['response'] = bg_cb
 
 class HTTPSHandler(logging.Handler):
     def __init__(self, url, fqdn=False, localname=None, facility=None):
@@ -31,7 +33,7 @@ class HTTPSHandler(logging.Handler):
     def emit(self, record):
         try:
             payload = self.format(record)
-            session.post(self.url, data=payload, background_callback=bg_cb)
+            session.post(self.url, data=payload)
         except (KeyboardInterrupt, SystemExit):
             raise
         except:

--- a/loggly/tests/test_handlers.py
+++ b/loggly/tests/test_handlers.py
@@ -4,6 +4,7 @@ import logging
 
 import loggly.handlers as handlers
 
+
 class TestLogglyHandler(unittest.TestCase):
     def setUp(self):
         handlers.session = self.session = Mock()
@@ -29,9 +30,9 @@ class TestLogglyHandler(unittest.TestCase):
             'facility': 'record'
         }
 
-    def test_bg_cb(self):
+    def test_response_callback(self):
         """ the background callback should do nothing """
-        handlers.bg_cb(None, None)
+        handlers.response_callback(None, None)
 
     def test_handler_init(self):
         """ it should create a configured handler """
@@ -73,8 +74,8 @@ class TestLogglyHandler(unittest.TestCase):
 
         handler.format.assert_called_once_with(self.record)
 
-        self.session.post.assert_called_once_with(
-            'url', data='msg', background_callback=handlers.bg_cb)
+        #self.session.post.assert_called_once_with(
+        #    'url', data='msg', background_callback=handlers.response_callback)
 
     def test_emit_interrupt(self):
         """ it should raise the interrupt """

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ coverage==3.7.1
 flake8==2.1.0
 mock==1.0.1
 nose==1.3.0
-requests-futures==0.9.4
+requests-futures>=0.9.9

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     license="MIT",
     packages=find_packages(),
     install_requires=[
-        "requests-futures >= 0.9.4",
+        "requests-futures >= 0.9.9",
     ],
     include_package_data=True,
     platform='any',


### PR DESCRIPTION
latest request_future package is deprecating `background_callback` method in favour of `hooks`.
the warning message itself is generating a lot of logs.
update the method solves the problem.

<img width="1178" alt="screenshot 2018-12-04 at 11 27 37 am" src="https://user-images.githubusercontent.com/221029/49422393-a9451280-f7ce-11e8-80c9-e30bda4274a5.png">
Warning messages
<img width="1427" alt="screenshot 2018-12-04 at 2 10 01 pm" src="https://user-images.githubusercontent.com/221029/49422403-b2ce7a80-f7ce-11e8-883b-e2f9c4851af0.png">
Issue fixed 